### PR TITLE
npm run test:coverageのカバレッジを100%になるようにテストを書いてください。

### DIFF
--- a/packages/bookmarklet/src/kaggleIframe/src/index.test.js
+++ b/packages/bookmarklet/src/kaggleIframe/src/index.test.js
@@ -1,0 +1,97 @@
+/**
+ * @jest-environment jsdom
+ */
+describe('kaggleIframe ブックマークレット実行', () => {
+
+  // 各テストの前にHTMLの構造をリセットする
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    // window.openのモックを設定
+    global.window.open = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('iframe要素のsrc属性を取得して新しいタブで開く', () => {
+    // 1. テスト用のDOMをセットアップ
+    document.body.innerHTML = `
+      <div>
+        <iframe src="https://example.com/notebook" width="100%" height="400"></iframe>
+        <p>その他のコンテンツ</p>
+      </div>
+    `;
+
+    // 2. テスト対象のスクリプトを実行
+    jest.isolateModules(() => {
+      require('./index.js');
+    });
+
+    // 3. 結果を検証
+    expect(window.open).toHaveBeenCalledWith('https://example.com/notebook', '_blank');
+    expect(window.open).toHaveBeenCalledTimes(1);
+  });
+
+  test('iframe要素が存在しない場合はundefinedで新しいタブを開こうとする', () => {
+    // 1. iframe要素のないDOMをセットアップ
+    document.body.innerHTML = `
+      <div>
+        <p>iframe要素がありません</p>
+        <video src="video.mp4"></video>
+      </div>
+    `;
+
+    // 2. スクリプトを実行してもエラーが起きないことを確認
+    expect(() => {
+      jest.isolateModules(() => {
+        require('./index.js');
+      });
+    }).not.toThrow();
+
+    // 3. 結果を検証（undefinedでwindow.openが呼ばれることを確認）
+    expect(window.open).toHaveBeenCalledWith(undefined, '_blank');
+    expect(window.open).toHaveBeenCalledTimes(1);
+  });
+
+  test('iframe要素にsrc属性が存在しない場合はnullで新しいタブを開こうとする', () => {
+    // 1. src属性のないiframe要素があるDOMをセットアップ
+    document.body.innerHTML = `
+      <div>
+        <iframe width="100%" height="400"></iframe>
+        <p>その他のコンテンツ</p>
+      </div>
+    `;
+
+    // 2. スクリプトを実行してもエラーが起きないことを確認
+    expect(() => {
+      jest.isolateModules(() => {
+        require('./index.js');
+      });
+    }).not.toThrow();
+
+    // 3. 結果を検証（nullでwindow.openが呼ばれることを確認）
+    expect(window.open).toHaveBeenCalledWith(null, '_blank');
+    expect(window.open).toHaveBeenCalledTimes(1);
+  });
+
+  test('複数のiframe要素がある場合は最初の要素のsrcを開く', () => {
+    // 1. 複数のiframe要素があるDOMをセットアップ
+    document.body.innerHTML = `
+      <div>
+        <iframe src="https://first-iframe.com" width="100%" height="400"></iframe>
+        <iframe src="https://second-iframe.com" width="100%" height="400"></iframe>
+        <iframe src="https://third-iframe.com" width="100%" height="400"></iframe>
+      </div>
+    `;
+
+    // 2. テスト対象のスクリプトを実行
+    jest.isolateModules(() => {
+      require('./index.js');
+    });
+
+    // 3. 結果を検証（最初のiframe要素のsrcのみが開かれる）
+    expect(window.open).toHaveBeenCalledWith('https://first-iframe.com', '_blank');
+    expect(window.open).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/bookmarklet/src/kaggleNotranslate/src/index.test.js
+++ b/packages/bookmarklet/src/kaggleNotranslate/src/index.test.js
@@ -1,0 +1,157 @@
+/**
+ * @jest-environment jsdom
+ */
+describe('kaggleNotranslate ブックマークレット実行', () => {
+
+  // 各テストの前にHTMLの構造をリセットする
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('input要素にnotranslateクラスを追加する', () => {
+    // 1. テスト用のDOMをセットアップ
+    document.body.innerHTML = `
+      <div>
+        <div class="input">
+          <p>入力エリア1</p>
+        </div>
+        <div class="input">
+          <p>入力エリア2</p>
+        </div>
+        <div class="other-class">
+          <p>その他のエリア</p>
+        </div>
+      </div>
+    `;
+
+    const inputElements = document.querySelectorAll('.input');
+    const otherElement = document.querySelector('.other-class');
+
+    // 実行前にnotranslateクラスがないことを確認
+    inputElements.forEach(element => {
+      expect(element.classList.contains('notranslate')).toBe(false);
+    });
+    expect(otherElement.classList.contains('notranslate')).toBe(false);
+
+    // 2. テスト対象のスクリプトを実行
+    jest.isolateModules(() => {
+      require('./index.js');
+    });
+
+    // 3. 結果を検証
+    inputElements.forEach(element => {
+      expect(element.classList.contains('notranslate')).toBe(true);
+    });
+    // 他のクラスは影響を受けないことを確認
+    expect(otherElement.classList.contains('notranslate')).toBe(false);
+  });
+
+  test('output_wrapper要素にnotranslateクラスを追加する', () => {
+    // 1. テスト用のDOMをセットアップ
+    document.body.innerHTML = `
+      <div>
+        <div class="output_wrapper">
+          <p>出力エリア1</p>
+        </div>
+        <div class="output_wrapper">
+          <p>出力エリア2</p>
+        </div>
+        <div class="other-wrapper">
+          <p>その他のラッパー</p>
+        </div>
+      </div>
+    `;
+
+    const outputElements = document.querySelectorAll('.output_wrapper');
+    const otherElement = document.querySelector('.other-wrapper');
+
+    // 実行前にnotranslateクラスがないことを確認
+    outputElements.forEach(element => {
+      expect(element.classList.contains('notranslate')).toBe(false);
+    });
+    expect(otherElement.classList.contains('notranslate')).toBe(false);
+
+    // 2. テスト対象のスクリプトを実行
+    jest.isolateModules(() => {
+      require('./index.js');
+    });
+
+    // 3. 結果を検証
+    outputElements.forEach(element => {
+      expect(element.classList.contains('notranslate')).toBe(true);
+    });
+    // 他のクラスは影響を受けないことを確認
+    expect(otherElement.classList.contains('notranslate')).toBe(false);
+  });
+
+  test('body要素のoverflowYスタイルをvisibleに設定する', () => {
+    // 1. テスト用のDOMをセットアップ
+    document.body.innerHTML = `
+      <div>
+        <p>コンテンツ</p>
+      </div>
+    `;
+
+    // 実行前のbodyのスタイルを確認（初期値は空文字）
+    const initialOverflowY = document.body.style.overflowY;
+
+    // 2. テスト対象のスクリプトを実行
+    jest.isolateModules(() => {
+      require('./index.js');
+    });
+
+    // 3. 結果を検証
+    expect(document.body.style.overflowY).toBe('visible');
+  });
+
+  test('input要素とoutput_wrapper要素が存在しない場合も正常に動作する', () => {
+    // 1. 対象要素のないDOMをセットアップ
+    document.body.innerHTML = `
+      <div>
+        <p>通常のコンテンツ</p>
+        <div class="other-class">その他のクラス</div>
+      </div>
+    `;
+
+    // 2. スクリプトを実行してもエラーが起きないことを確認
+    expect(() => {
+      jest.isolateModules(() => {
+        require('./index.js');
+      });
+    }).not.toThrow();
+
+    // 3. bodyのスタイルは変更されることを確認
+    expect(document.body.style.overflowY).toBe('visible');
+  });
+
+  test('inputとoutput_wrapper要素が混在する場合の動作確認', () => {
+    // 1. 混在するDOMをセットアップ
+    document.body.innerHTML = `
+      <div>
+        <div class="input">入力エリア</div>
+        <div class="output_wrapper">出力エリア</div>
+        <div class="input">入力エリア2</div>
+        <div class="unrelated">関係ないエリア</div>
+      </div>
+    `;
+
+    const inputElements = document.querySelectorAll('.input');
+    const outputElements = document.querySelectorAll('.output_wrapper');
+    const unrelatedElement = document.querySelector('.unrelated');
+
+    // 2. テスト対象のスクリプトを実行
+    jest.isolateModules(() => {
+      require('./index.js');
+    });
+
+    // 3. 結果を検証
+    inputElements.forEach(element => {
+      expect(element.classList.contains('notranslate')).toBe(true);
+    });
+    outputElements.forEach(element => {
+      expect(element.classList.contains('notranslate')).toBe(true);
+    });
+    expect(unrelatedElement.classList.contains('notranslate')).toBe(false);
+    expect(document.body.style.overflowY).toBe('visible');
+  });
+});

--- a/packages/bookmarklet/src/markdownShare/src/index.test.js
+++ b/packages/bookmarklet/src/markdownShare/src/index.test.js
@@ -1,0 +1,45 @@
+/**
+ * @jest-environment jsdom
+ */
+describe('markdownShare ブックマークレット実行', () => {
+
+  // 各テストの前にHTMLの構造をリセットする
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    // navigator.shareのモックを設定
+    global.navigator.share = jest.fn().mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('現在のページ情報をMarkdown形式でシェアする', async () => {
+    // 2. テスト対象のスクリプトを実行
+    jest.isolateModules(() => {
+      require('./index.js');
+    });
+
+    // 3. 結果を検証
+    expect(navigator.share).toHaveBeenCalledWith({
+      text: `[${document.title}](${document.location.href})`
+    });
+    expect(navigator.share).toHaveBeenCalledTimes(1);
+  });
+
+  test('navigator.shareが利用できない場合はエラーが発生する', () => {
+    // 1. navigator.shareを削除
+    const originalShare = global.navigator.share;
+    delete global.navigator.share;
+
+    // 2. スクリプトを実行するとエラーが発生することを確認
+    expect(() => {
+      jest.isolateModules(() => {
+        require('./index.js');
+      });
+    }).toThrow('navigator.share is not a function');
+
+    // 元に戻す
+    global.navigator.share = originalShare;
+  });
+});

--- a/packages/bookmarklet/src/selectionEdit/src/index.test.js
+++ b/packages/bookmarklet/src/selectionEdit/src/index.test.js
@@ -1,0 +1,127 @@
+/**
+ * @jest-environment jsdom
+ */
+describe('selectionEdit ブックマークレット実行', () => {
+
+  // 各テストの前にHTMLの構造をリセットする
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    // window.promptのモックを設定
+    global.window.prompt = jest.fn();
+    // window.getSelectionのモックを設定
+    global.window.getSelection = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('選択されたテキストをプロンプトに表示する', () => {
+    // 1. テスト用の選択テキストを設定
+    const mockSelection = {
+      toString: jest.fn().mockReturnValue('選択されたテキスト')
+    };
+    window.getSelection.mockReturnValue(mockSelection);
+
+    // 2. テスト対象のスクリプトを実行
+    jest.isolateModules(() => {
+      require('./index.js');
+    });
+
+    // 3. 結果を検証
+    expect(window.getSelection).toHaveBeenCalledTimes(1);
+    expect(mockSelection.toString).toHaveBeenCalledTimes(1);
+    expect(window.prompt).toHaveBeenCalledWith('', '選択されたテキスト');
+  });
+
+  test('テキストが選択されていない場合は空文字をプロンプトに表示する', () => {
+    // 1. 空の選択テキストを設定
+    const mockSelection = {
+      toString: jest.fn().mockReturnValue('')
+    };
+    window.getSelection.mockReturnValue(mockSelection);
+
+    // 2. テスト対象のスクリプトを実行
+    jest.isolateModules(() => {
+      require('./index.js');
+    });
+
+    // 3. 結果を検証
+    expect(window.getSelection).toHaveBeenCalledTimes(1);
+    expect(mockSelection.toString).toHaveBeenCalledTimes(1);
+    expect(window.prompt).toHaveBeenCalledWith('', '');
+  });
+
+  test('getSelectionがnullを返す場合でもエラーにならない', () => {
+    // 1. getSelectionがnullを返すように設定
+    window.getSelection.mockReturnValue(null);
+
+    // 2. スクリプトを実行してもエラーが起きないことを確認
+    expect(() => {
+      jest.isolateModules(() => {
+        require('./index.js');
+      });
+    }).not.toThrow();
+
+    // 3. 結果を検証
+    expect(window.getSelection).toHaveBeenCalledTimes(1);
+    expect(window.prompt).toHaveBeenCalledWith('', undefined);
+  });
+
+  test('複数行のテキストが選択されている場合も正常に動作する', () => {
+    // 1. 複数行のテキストを設定
+    const multilineText = '1行目のテキスト\n2行目のテキスト\n3行目のテキスト';
+    const mockSelection = {
+      toString: jest.fn().mockReturnValue(multilineText)
+    };
+    window.getSelection.mockReturnValue(mockSelection);
+
+    // 2. テスト対象のスクリプトを実行
+    jest.isolateModules(() => {
+      require('./index.js');
+    });
+
+    // 3. 結果を検証
+    expect(window.getSelection).toHaveBeenCalledTimes(1);
+    expect(mockSelection.toString).toHaveBeenCalledTimes(1);
+    expect(window.prompt).toHaveBeenCalledWith('', multilineText);
+  });
+
+  test('特殊文字を含むテキストが選択されている場合も正常に動作する', () => {
+    // 1. 特殊文字を含むテキストを設定
+    const specialText = 'HTML要素: <div>test</div> & "quotes" \'single\'';
+    const mockSelection = {
+      toString: jest.fn().mockReturnValue(specialText)
+    };
+    window.getSelection.mockReturnValue(mockSelection);
+
+    // 2. テスト対象のスクリプトを実行
+    jest.isolateModules(() => {
+      require('./index.js');
+    });
+
+    // 3. 結果を検証
+    expect(window.getSelection).toHaveBeenCalledTimes(1);
+    expect(mockSelection.toString).toHaveBeenCalledTimes(1);
+    expect(window.prompt).toHaveBeenCalledWith('', specialText);
+  });
+
+  test('日本語テキストが選択されている場合も正常に動作する', () => {
+    // 1. 日本語テキストを設定
+    const japaneseText = 'これは日本語のテキストです。漢字、ひらがな、カタカナが含まれています。';
+    const mockSelection = {
+      toString: jest.fn().mockReturnValue(japaneseText)
+    };
+    window.getSelection.mockReturnValue(mockSelection);
+
+    // 2. テスト対象のスクリプトを実行
+    jest.isolateModules(() => {
+      require('./index.js');
+    });
+
+    // 3. 結果を検証
+    expect(window.getSelection).toHaveBeenCalledTimes(1);
+    expect(mockSelection.toString).toHaveBeenCalledTimes(1);
+    expect(window.prompt).toHaveBeenCalledWith('', japaneseText);
+  });
+});


### PR DESCRIPTION
```
> /cost 
  ⎿  Total cost:            $0.85
     Total duration (API):  7m 41.3s
     Total duration (wall): 10m 42.6s
     Total code changes:    679 lines added, 253 lines removed
     Token usage by model:
         claude-3-5-haiku:  2.7k input, 250 output, 0 cache read, 0 cache write
            claude-sonnet:  54 input, 19.4k output, 1.2m cache read, 50.4k cache write
```